### PR TITLE
fix do not set consolidate after if consolidation enabled

### DIFF
--- a/charts/karpenter_nodes/Chart.yaml
+++ b/charts/karpenter_nodes/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: karpenter_nodes
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart for generating NodeClasses and NodePools for Karpenter
 maintainers:
   - name: nadavbuc

--- a/charts/karpenter_nodes/templates/nodepool.yaml
+++ b/charts/karpenter_nodes/templates/nodepool.yaml
@@ -195,7 +195,9 @@ spec:
   disruption:
     expireAfter: {{ $v.expireAfter | default $.Values.expireAfter }}
     consolidationPolicy: {{$v.consolidationPolicy | default $.Values.consolidationPolicy}}
+    {{- if eq ($v.consolidationPolicy | default $.Values.consolidationPolicy) "WhenEmpty" }}
     consolidateAfter: {{ $v.consolidateAfter | default $.Values.consolidateAfter }}
+    {{- end }}
     {{- if $v.budgets }}
     budgets:
     {{- toYaml $v.budgets | nindent 6 }}

--- a/charts/karpenter_nodes/tests/nodepool_nodes_default_test.yaml
+++ b/charts/karpenter_nodes/tests/nodepool_nodes_default_test.yaml
@@ -146,9 +146,8 @@ tests:
       - equal:
           path: spec.disruption.consolidationPolicy
           value: WhenUnderutilized
-      - equal:
+      - isNull:
           path: spec.disruption.consolidateAfter
-          value: 5m
       - isNull:
           path: spec.disruption.budgets
       - isNull:


### PR DESCRIPTION
<!-- Thank you for contributing!-->
### Changes
Set `consolidateAfter` only when policy is `whenEmpty`
Fixes 
```
NodePool.karpenter.sh "nodes-default-amd64" is invalid: spec.disruption: Invalid value: "object": consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
```

### Checklist

- [x] README is updated with new configuration values *(if applicable)*
- [x] Changes were tested and verified locally
- [x] Changes are covered by Unit Tests
- [x] Version is bumped in `Chart.yaml`

<!--### Fixes!-->
